### PR TITLE
chore: update DO bucket URL to remote-falcon-uploads

### DIFF
--- a/templates/lumos-light-show.html
+++ b/templates/lumos-light-show.html
@@ -495,7 +495,7 @@ might not display correctly
 -->
 
 <div id="header_Img_Content">
-    <img src="https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/lumoslightshow/lls-logo-2025-rounded-reduced.png" style="max-width: 70%;height:auto;margin: auto;">   
+    <img src="https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/lumoslightshow/lls-logo-2025-rounded-reduced.png" style="max-width: 70%;height:auto;margin: auto;">   
 </div>
   
 <!-- This section will display a message if your show isn't

--- a/templates/purple-halloween.html
+++ b/templates/purple-halloween.html
@@ -39,7 +39,7 @@
       BODY
     *******/
     body {
-        background-image: url('https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_background.png');
+        background-image: url('https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_background.png');
         background-repeat: no-repeat;
         -webkit-background-size: cover;
         -moz-background-size: cover;
@@ -459,9 +459,9 @@
 
 <!-----START OF PAGE DESIGN----->
 
-<div id="header_img_content"> <img src="https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_header.png" style="width:100%; height: auto; margin: auto;"> </div>
+<div id="header_img_content"> <img src="https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_header.png" style="width:100%; height: auto; margin: auto;"> </div>
 
-<div id="your_logo"> <img src="https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_your_logo.png" style="width:10%; height:auto; margin:  auto; position:center ;"> </div>
+<div id="your_logo"> <img src="https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_your_logo.png" style="width:10%; height:auto; margin:  auto; position:center ;"> </div>
 
 <br />
 
@@ -484,7 +484,7 @@
     <!-- This section will be displayed if your show isn't playing a scheduled playlist-->
 
     <div {after-hours-message}>
-        <img src="https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_see_you_soon.png" alt="off-air" style="max-width: 25%;height:auto;margin: auto;">
+        <img src="https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_see_you_soon.png" alt="off-air" style="max-width: 25%;height:auto;margin: auto;">
         <div class="pink-title">
             Show Hours</div>
         <div class="body_text">
@@ -694,5 +694,5 @@
             alt="" width="35" height="35"/> </a>
 </div>
 <div id="footer">
-    <img src="https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_footer.png" style="width:100%; height: auto; margin: auto;">
+    <img src="https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com/__global__/purple_halloween_footer.png" style="width:100%; height: auto; margin: auto;">
 </div>


### PR DESCRIPTION
## Summary
- Repoint image references in `templates/lumos-light-show.html` and `templates/purple-halloween.html` from the legacy `remote-falcon-images.nyc3.cdn.digitaloceanspaces.com` bucket to `remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com`.
- 6 references updated total (1 in lumos-light-show, 5 in purple-halloween).

## Test plan
- [ ] Confirm the new bucket serves the referenced assets (logos, backgrounds, headers, footers, off-air image).
- [ ] Load both templates in a browser and verify all images render.