### PR TITLE
feat: add {VOTES_REMAINING} token to all templates

### DIFF
--- a/templates/dynamic-menu.html
+++ b/templates/dynamic-menu.html
@@ -603,6 +603,8 @@
 					</div>
 				</div>
 				<div {playlist-voting-dynamic-container}>
+					<!-- Shows "X of N votes left this show" when a per-voter vote limit is set (Remote Falcon #162). Renders nothing when no limit is configured. -->
+					<div class="body_text" id="votes-remaining" style="text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
 					<div class="rtable">
 						<div class="cell-vote-playlist" style="border: none; cursor: text">
 							Song List

--- a/templates/lumos-light-show.html
+++ b/templates/lumos-light-show.html
@@ -593,6 +593,9 @@ is no need to delete it if you are using the Jukebox mode, and you might change 
 mind on the selection method later!  -->
 
 <div {playlist-voting-dynamic-container}>
+    <!-- Shows "X of N votes left this show" when a per-voter vote limit is set
+    (Remote Falcon #162). Renders nothing when no limit is configured. -->
+    <div class="body_text" id="votes-remaining" style="text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
 	<div class="rtable">
         <div class="cell-vote-playlist" style="border: none; cursor: text">
             Song List

--- a/templates/on-air.html
+++ b/templates/on-air.html
@@ -591,6 +591,9 @@
         mind on the selection method later! -->
         <br />
 
+        <!-- Shows "X of N votes left this show" when a per-voter vote limit is set
+        (Remote Falcon #162). Renders nothing when no limit is configured. -->
+        <div id="votes-remaining" style="font-family: 'Fredericka the Great', cursive; text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
         <div class="rtable">
             <div class="cell-vote-playlist" style="font-family: 'Fredericka the Great', cursive;border: none; cursor: text">
                 <H2>Pick Below</H2>

--- a/templates/purple-halloween.html
+++ b/templates/purple-halloween.html
@@ -574,6 +574,9 @@
     mind on the selection method later! -->
 
     <div {playlist-voting-dynamic-container}>
+        <!-- Shows "X of N votes left this show" when a per-voter vote limit is set
+        (Remote Falcon #162). Renders nothing when no limit is configured. -->
+        <div class="body_text" id="votes-remaining" style="text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
         <div class="rtable">
             <div class="cell-vote-playlist" style="border: none; cursor: text">
                 Song List

--- a/templates/red-and-white.html
+++ b/templates/red-and-white.html
@@ -492,6 +492,9 @@
   mind on the selection method later! -->
 
     <div {playlist-voting-dynamic-container}>
+        <!-- Shows "X of N votes left this show" when a per-voter vote limit is set
+        (Remote Falcon #162). Renders nothing when no limit is configured. -->
+        <div class="body_text" id="votes-remaining" style="text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
         <div class="rtable">
             <div class="cell-vote-playlist" style="border: none; font-weight:bold; text-decoration: underline; cursor: text"> Song List </div>
             <div class="cell-vote" style="border: none; font-weight:bold; text-decoration: underline; cursor: text"> Votes </div>

--- a/templates/the-og.html
+++ b/templates/the-og.html
@@ -546,6 +546,10 @@ is no need to delete it if you are using the Jukebox mode, and you might change 
 mind on the selection method later! -->
 
 <div {playlist-voting-dynamic-container}>
+    <!-- Shows "X of N votes left this show" when a per-voter vote limit is set
+    (Remote Falcon #162). Renders nothing when no limit is configured, so it's
+    safe to leave in place. -->
+    <div class="body_text" id="votes-remaining" style="text-align: center; margin: 0 0 12px;">{VOTES_REMAINING}</div>
     <div class="rtable">
         <div class="cell-vote-playlist" style="border: none; cursor: text">
             Song List


### PR DESCRIPTION
## Summary

Adds the `{VOTES_REMAINING}` token to all 6 viewer-page templates so the new per-viewer **"X of N votes left this show"** countdown (Remote Falcon **#162**) appears out-of-the-box.

The token is placed inside each template's **voting song-list container**, just above the list, styled with that template's own classes. The platform substitutes it only when the show is in **voting mode with a per-voter vote limit set**; otherwise it renders nothing (jukebox mode, no limit, or vote-exempt viewers), so it's safe in every template.

## Templates updated
- `the-og.html` (the default page fetched on signup)
- `lumos-light-show.html`
- `on-air.html`
- `purple-halloween.html`
- `red-and-white.html`
- `dynamic-menu.html`

## Notes
- Additive only (+18 lines); each token is the **sole child** of its element, as the RF viewer's token matcher requires.
- Pairs with the platform PR that ships the `{VOTES_REMAINING}` mechanism (remote-falcon-platform #116).